### PR TITLE
Fix missing names for tacwrap variations

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/scarfs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Masks/scarfs.yml
@@ -43,7 +43,7 @@
 - type: entity
   parent: RMCBaseScarfMask
   id: RMCMaskScarfAlpha
-  name: tactical wrap
+  name: alpha tactical wrap
   description: A tactical wrap used by soldiers to conceal their face.
   components:
   - type: Sprite
@@ -56,11 +56,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfAlpha]
   id: RMCMaskScarfAlphaDown
-  name: tactical wrap
+  name: alpha tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfBravo
+  name: bravo tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/bravo.rsi
@@ -70,11 +71,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfBravo]
   id: RMCMaskScarfBravoDown
-  name: tactical wrap
+  name: bravo tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfCharlie
+  name: charlie tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/charlie.rsi
@@ -84,11 +86,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfCharlie]
   id: RMCMaskScarfCharlieDown
-  name: tactical wrap
+  name: charlie tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfDelta
+  name: delta tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/delta.rsi
@@ -98,11 +101,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfDelta]
   id: RMCMaskScarfDeltaDown
-  name: tactical wrap
+  name: delta tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfEcho
+  name: echo tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/echo.rsi
@@ -112,11 +116,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfEcho]
   id: RMCMaskScarfEchoDown
-  name: tactical wrap
+  name: echo tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfFoxtrot
+  name: foxtrot tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/foxtrot.rsi
@@ -126,13 +131,14 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfFoxtrot]
   id: RMCMaskScarfFoxtrotDown
-  name: tactical wrap
+  name: foxtrot tactical wrap
 
 # COLOURS
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfRed
+  name: red tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/alpha.rsi
@@ -142,11 +148,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfRed]
   id: RMCMaskScarfRedDown
-  name: tactical wrap
+  name: red tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfBlack
+  name: black tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/black.rsi
@@ -156,11 +163,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfBlack]
   id: RMCMaskScarfBlackDown
-  name: tactical wrap
+  name: black tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfGray
+  name: grey tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/gray.rsi
@@ -170,11 +178,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfGray]
   id: RMCMaskScarfGrayDown
-  name: tactical wrap
+  name: grey tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfGreen
+  name: green tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/green.rsi
@@ -184,11 +193,12 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfGreen]
   id: RMCMaskScarfGreenDown
-  name: tactical wrap
+  name: green tactical wrap
 
 - type: entity
   parent: RMCMaskScarfAlpha
   id: RMCMaskScarfTan
+  name: tan tactical wrap
   components:
   - type: Sprite
     sprite: _RMC14/Objects/Clothing/Mask/Scarfs/tan.rsi
@@ -198,4 +208,4 @@
 - type: entity
   parent: [RMCBaseScarfDown, RMCMaskScarfTan]
   id: RMCMaskScarfTanDown
-  name: tactical wrap
+  name: tan tactical wrap


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Previously, every tacwrap color and variation all had the name of "tactical wrap" with no prefix to indicate the color or squad they represent. This is a very simple fix of adding the color or squad the clothing represents to it's name.

## Why / Balance
The headbands, which act very similarly to the tacwrap, all have an extra word to indicate their color or squad. It should be obvious that the tacwrap should do the same.

## Media
Before:
![image](https://github.com/user-attachments/assets/c071f522-c09b-4036-b119-d352322a12b2)

After:
![image](https://github.com/user-attachments/assets/13d387e0-103c-43e0-99fd-d4f00d08b3d4)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.